### PR TITLE
fix: keep package.json biome-formatted after changeset version

### DIFF
--- a/.changeset/fix-release-lint-formatting.md
+++ b/.changeset/fix-release-lint-formatting.md
@@ -1,0 +1,5 @@
+---
+"decorated-factory": patch
+---
+
+Keep `package.json` formatted by Biome after `changeset version` runs, so the release commit does not break the lint step in CI.

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
 	"main": "dist/index.cjs.js",
 	"module": "dist/index.esm.js",
 	"license": "MIT",
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"keywords": [
 		"factory",
 		"decorators",
@@ -40,7 +38,7 @@
 		"test:coverage": "vitest --coverage --run",
 		"prebuild": "rimraf -g dist",
 		"build": "rollup -c",
-		"version": "changeset version",
+		"version": "changeset version && biome format --write package.json",
 		"release": "npm run build && changeset publish",
 		"prelocal-pack": "rimraf -g decorated-factory-*.tgz",
 		"local-pack": "npm pack"


### PR DESCRIPTION
changeset version reformats package.json with multiline arrays, which the biome lint step rejects, breaking CI on every release. Run biome format on package.json right after the bump so the release commit stays lint-clean.